### PR TITLE
fixed: double 'tags:'

### DIFF
--- a/tasks/backported-kernel.yml
+++ b/tasks/backported-kernel.yml
@@ -30,7 +30,6 @@
   when: backported_kernel_result | changed
   connection: local
   tags:
-  tags:
     - docker-backported-kernel-apply
     - docker-backported-kernel-reboot
     - docker-backported-kernel-reboot-wait


### PR DESCRIPTION
in tasks/backported-kernel.yml, line 32 there is an empty 'tags:'
```
[WARNING]: While constructing a mapping from
/provisioning/roles/tersmitten.docker/tasks/backported-kernel.yml, line 22,
column 3, found a duplicate dict key (tags).  Using last defined value only.
```