### PR TITLE
fixed: deprecated 'sudo'

### DIFF
--- a/tasks/backported-kernel.yml
+++ b/tasks/backported-kernel.yml
@@ -26,7 +26,7 @@
     delay: 15
     timeout: 600
     state: started
-  sudo: false
+  become: false
   when: backported_kernel_result | changed
   connection: local
   tags:


### PR DESCRIPTION
in tasks/backported-kernel.yml, line 29 ansible 2.1.1 moans about the use of sudo:

```
[DEPRECATION WARNING]: Instead of sudo/sudo_user, use become/become_user and 
make sure become_method is 'sudo' (default).
This feature will be removed in a 
future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
```